### PR TITLE
HSM Passphrase script - Two double quotes - Must be one

### DIFF
--- a/content/en/docs/apim_administration/apigtw_admin/general_certificates.md
+++ b/content/en/docs/apim_administration/apigtw_admin/general_certificates.md
@@ -278,7 +278,7 @@ To configure an automatic PIN passphrase, perform the following steps:
             <EngineCommand when="preInit" name="REALMS_DIR"
                  value="$VINSTDIR/conf/certrealms" />
             <EngineCommand when="preInit" name="PASSPHRASE_EXEC"
-                 value=""$VDISTDIR/hsmpin.sh"" />
+                 value="$VDISTDIR/hsmpin.sh" />
         </Engine>
         </ConfigurationFragment>
     ```


### PR DESCRIPTION
## Describe the changes

The page: https://docs.axway.com/bundle/axway-open-docs/page/docs/apim_administration/apigtw_admin/general_certificates/index.html is documenting how to setup the passphrase script and gives this example:
`<EngineCommand when="preInit" name="PASSPHRASE_EXEC"
             value=""$VDISTDIR/hsmpin.sh"" />`

But with that it leads to the following error:
XML parse failed for "conf/vpkcs11.xml" / "": line 9: whitespace expected

It must be:
`<EngineCommand when="preInit" name="PASSPHRASE_EXEC"
             value="$VDISTDIR/hsmpin.sh" />`

## Checklist for contributors

Before submitting this PR, please make sure:

* [ ] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [ ] You have signed the [Axway CLA](https://cla.axway.com/)
* [ ] You have verified the technical accuracy of your change
* [ ] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [ ] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)
* [ ] You have verified that all status checks have passed

_Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your change._

## Checklist for approvers

_This section is to be filled out by project maintainers only._

Before approving this PR, please make sure it:

* [ ] Passes all status checks
* [ ] Does not have conflicts with the base branch
* [ ] Is clear and complete
* [ ] Is believed to be accurate (technical accuracy to be checked with an SME for PRs originating from outside R&D)
* [ ] Follows [Axway style](https://techweb.axway.com/confluence/display/RIE/Style+guide)
* [ ] Follows [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)
* [ ] Follows [best practices](https://axway-open-docs.netlify.com/docs/contribution_guidelines/bestpracticedevdoc/)
* [ ] Does not contain typos, grammatical errors, etc.
* [ ] Does not expose any sensitive information
* [ ] Passes the Markdown linter rules (automated via CI check)
* [ ] Does not contain broken links
* [ ] Is discoverable and navigable

## Checklist for mergers

_This section is to be filled out by project maintainers only._

Before merging this PR, please make sure:

* [ ] You have applied a size label (unless this work is tracked in the ReadMeFirst JIRA project)
* [ ] You have applied a production label if this needs a manual push to Zoomin
* [ ] You have added it to the correct GitHub project
* [ ] You have added it to the correct Sprint milestone
* [ ] You have appended a `fixes` line to this description if this PR fixes a specific GitHub issue
* [ ] You have added a new collection to Netlify CMS config (static/admin/config.js) if required (new doc sections)
* [ ] You have updated the Zoomin classification file if required (new AMPC topics)
